### PR TITLE
Change Filament Runout pin to the Z endstop Sidewinder X2

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1762,7 +1762,7 @@
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)
   #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
   #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
-
+  #define FIL_RUNOUT_PIN PA0              // Sets the Filament Runout sensor to the Z Endstop so that u can monitor it with Octoprint
   #define FIL_RUNOUT_STATE     LOW        // Pin state indicating that filament is NOT present.
   #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.


### PR DESCRIPTION
<!--

Added #define FIL_RUNOUT_PIN PA0 at 1765 so that we can use the existing Filament runout sensor cause rn if u Print with Octoprint there is no way the Printer knows when it is out of filament. So it will keep printing without filament. 

Basicly enabling the Board to know when there is no more Filament and not the LCD which usally takes control of that.

-->

### Requirements

On physical printer you will need to unplug your filament sensor from the lower connector and take the long wire out that goes down the left Z axis Bar. This will need to be routed exactly the same way except down the right Z axis bar.
the lower connector will plug directly in to the open plug on the lower right side (black connector that went to the original Z stop for the X1) make sure when you plug this in that the brown/blue/black wires correspond to the wires in the harness, This plug is capable of being plugged in backwards and it will not work.

### Benefits

Usability enables the use of the Filament Runout Sensor with e.g. Ocotoprint

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. --> (Maybe i didnt look through)
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/11473239/Configuration.zip)
